### PR TITLE
added feature to undo add and remove from reading list

### DIFF
--- a/libs/books/data-access/src/lib/+state/reading-list.actions.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.actions.ts
@@ -1,5 +1,6 @@
 import { createAction, props } from '@ngrx/store';
 import { Book, ReadingListItem } from '@tmo/shared/models';
+import { State } from './reading-list.reducer';
 
 export const init = createAction('[Reading List] Initialize');
 
@@ -40,4 +41,10 @@ export const failedRemoveFromReadingList = createAction(
 export const confirmedRemoveFromReadingList = createAction(
   '[Reading List API] Confirmed remove from list',
   props<{ item: ReadingListItem }>()
+);
+
+export const takeSnapshot = createAction('[Snapshot] Take Snapshot');
+
+export const restoreSnapshot = createAction(
+  '[Snapshot] Restore Snapshot'  
 );

--- a/libs/books/feature/src/lib/book-search/book-search.component.ts
+++ b/libs/books/feature/src/lib/book-search/book-search.component.ts
@@ -5,11 +5,14 @@ import {
   clearSearch,
   getAllBooks,
   ReadingListBook,
-  searchBooks
+  restoreSnapshot,
+  searchBooks,
+  takeSnapshot
 } from '@tmo/books/data-access';
 import { FormBuilder } from '@angular/forms';
 import { Book } from '@tmo/shared/models';
 import { Subscription } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'tmo-book-search',
@@ -26,7 +29,8 @@ export class BookSearchComponent implements OnInit, OnDestroy {
 
   constructor(
     private readonly store: Store,
-    private readonly fb: FormBuilder
+    private readonly fb: FormBuilder,
+    private readonly snackBar: MatSnackBar
   ) {}
 
   get searchTerm(): string {
@@ -46,7 +50,15 @@ export class BookSearchComponent implements OnInit, OnDestroy {
   }
 
   addBookToReadingList(book: Book) {
+    this.store.dispatch(takeSnapshot());
     this.store.dispatch(addToReadingList({ book }));
+    const snackBarRef = this.snackBar.open(`${book.title} has been added to the reading list`, 'Undo', {
+      duration: 3000,
+    });
+
+    snackBarRef.onAction().subscribe(() => {
+      this.store.dispatch(restoreSnapshot());
+    });
   }
 
   searchExample() {

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.ts
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { Store } from '@ngrx/store';
-import { getReadingList, removeFromReadingList } from '@tmo/books/data-access';
+import { getReadingList, removeFromReadingList, restoreSnapshot, takeSnapshot } from '@tmo/books/data-access';
 
 @Component({
   selector: 'tmo-reading-list',
@@ -10,9 +11,16 @@ import { getReadingList, removeFromReadingList } from '@tmo/books/data-access';
 export class ReadingListComponent {
   readingList$ = this.store.select(getReadingList);
 
-  constructor(private readonly store: Store) {}
+  constructor(private readonly store: Store, private readonly snackBar: MatSnackBar) {}
 
   removeFromReadingList(item) {
+    this.store.dispatch(takeSnapshot());
     this.store.dispatch(removeFromReadingList({ item }));
+    const snackBarRef = this.snackBar.open(`${item.title} has been removed from the reading list`, 'Undo', {
+      duration: 3000,
+    });
+    snackBarRef.onAction().subscribe(() => {
+      this.store.dispatch(restoreSnapshot());
+    });
   }
 }


### PR DESCRIPTION
added feature to undo add and remove from reading list. 

Use snapshot mechanism where I take the snapshot of the current state before dispatch an addBook or removeBook related action. Then when and if I click undo, the snapshot is reinstated as current state. Also, I keep the display of snackBar to 3000ms for optimal user experience.